### PR TITLE
Logic to extract the goldstandard file from folder

### DIFF
--- a/score.py
+++ b/score.py
@@ -8,16 +8,18 @@ Metrics to return:
 
 import argparse
 import json
+import os
 
 import pandas as pd
 from sklearn.metrics import roc_auc_score, average_precision_score
 
+from glob import glob
 
 def get_args():
     """Set up command-line interface and get arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--predictions_file", type=str, required=True)
-    parser.add_argument("-g", "--goldstandard_file", type=str, required=True)
+    parser.add_argument("-g", "--goldstandard_folder", type=str, required=True)
     parser.add_argument("-o", "--output", type=str, default="results.json")
     return parser.parse_args()
 
@@ -31,6 +33,15 @@ def score(gold, gold_col, pred, pred_col):
     return {"auc_roc": roc, "auprc": pr}
 
 
+def extract_gs_file(folder):
+    """Extract gold standard file from folder."""
+    files = glob(os.path.join(folder, "*"))
+    if len(files) != 1:
+        raise ValueError(f"Expected exactly one gold standard file in folder. Got {len(files)}. Exiting.")
+
+    return files[0]
+
+
 def main():
     """Main function."""
     args = get_args()
@@ -38,9 +49,11 @@ def main():
     with open(args.output, encoding="utf-8") as out:
         res = json.load(out)
 
+    gold_file = extract_gs_file(args.goldstandard_folder)
+
     if res.get("validation_status") == "VALIDATED":
         pred = pd.read_csv(args.predictions_file)
-        gold = pd.read_csv(args.goldstandard_file)
+        gold = pd.read_csv(gold_file)
         scores = score(gold, "disease", pred, "disease_probability")
         status = "SCORED"
     else:

--- a/validate.py
+++ b/validate.py
@@ -8,9 +8,12 @@ Prediction file should be a 2-column CSV file, where:
 
 import argparse
 import json
+import os
 
-import pandas as pd
 import numpy as np
+import pandas as pd
+
+from glob import glob
 
 EXPECTED_COLS = {
     'id': str,
@@ -23,7 +26,7 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--predictions_file",
                         type=str, required=True)
-    parser.add_argument("-g", "--goldstandard_file",
+    parser.add_argument("-g", "--goldstandard_folder",
                         type=str, required=True)
     parser.add_argument("-o", "--output",
                         type=str, default="results.json")
@@ -82,10 +85,20 @@ def check_prob_values(pred):
     return ""
 
 
-def validate(gold_file, pred_file):
+def extract_gs_file(folder):
+    """Extract gold standard file from folder."""
+    files = glob(os.path.join(folder, "*"))
+    if len(files) != 1:
+        raise ValueError(f"Expected exactly one gold standard file in folder. Got {len(files)}. Exiting.")
+
+    return files[0]
+
+
+def validate(gold_folder, pred_file):
     """Validate predictions file against goldstandard."""
     errors = []
 
+    gold_file = extract_gs_file(gold_folder)
     gold = pd.read_csv(gold_file, index_col="id")
     try:
         pred = pd.read_csv(
@@ -117,7 +130,7 @@ def main():
             errors = [f.read()]
     else:
         errors = validate(
-            gold_file=args.goldstandard_file,
+            gold_folder=args.goldstandard_folder,
             pred_file=args.predictions_file
         )
 


### PR DESCRIPTION
### problem
The `model2data` workflow stages the goldstandard file inside a folder on S3. The workflow will provide the folder in which the gs file is housed, so that extracting the file is handled in the validation/scoring scripts.

### solution

for both `validate.py` and `score.py` I did the following:
- [x] introduce a new function `extract_gs_file` to extract the gs file from the folder
- [x] update the `goldstandard_file` arg to `goldstandard_folder`
- [x] update all code dependent on this arg

### testing & preview

NO sensitive data is shared below:

I downloaded one of the gs files available [here](https://www.synapse.org/#!Synapse:syn52817033/wiki/624337), and generated a `predictions.csv` with the same exact content. The script was able to run through successfully.

<img width="829" alt="image" src="https://github.com/Sage-Bionetworks-Challenges/pegs-evaluation/assets/32107699/80c92d1b-48d9-4fec-b87e-e138f89ca4cd">

----

As a side note, I found it suspicious that I was getting an `INVALID` result for val/score when my `predictions.csv` was identical to the goldstandard. I printed the `invalid_reasons` and was getting formatting errors, one of them being:
```
Invalid column names and/or types: Usecols do not match columns, columns expected but not found: ['disease_probability']. Expecting: {'id': <class 'str'>, 'disease_probability': <class 'numpy.float64'>}.
```

This is out of scope of the PR, but I just wanted to share in case it's something that needs to be looked at before we move forward with the stress testing.